### PR TITLE
🐘 Enable `org.gradle.tooling.parallel`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 
 android.useAndroidX=true
 kotlin.code.style=official


### PR DESCRIPTION
Add `org.gradle.tooling.parallel=true` to enable parallel tooling daemon processes for faster builds.